### PR TITLE
Target refuses to make, unescaped brace in regex

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-Read the documentation in qemu-doc.html.
-
-Fabrice Bellard.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,8 @@
+# QEMU iOS Emulator
+--------------------
+## QEMU s5l89xx Port
+
+
+
+# Credits
+Made possible by [cmw](https://github.com/cmwdotme/).

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,7 @@
-# QEMU iOS Emulator
---------------------
-## QEMU s5l89xx Port
+### QEMU iOS Emulator
+#### QEMU s5l89xx Port
 
 
 
-# Credits
+### Credits
 Made possible by [cmw](https://github.com/cmwdotme/).


### PR DESCRIPTION
`make `

                                                                                       
 ```
 GEN   qemu.1
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/^\@strong{ <-- HERE (.*)}$/ at /home/clayton/qemu-ios/scripts/texi2pod.pl line 313.
qemu.pod around line 95: Non-ASCII character seen before =encoding in 'Sch�tz.'. Assuming UTF-8
POD document had syntax errors at /usr/bin/core_perl/pod2man line 69.
make: *** [Makefile:268: qemu.1] Error 255
make: *** Deleting file 'qemu.1'
```
